### PR TITLE
Feature: fix deployment; disable SSR

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -67,6 +67,8 @@
                     },
                     "configurations": {
                         "production": {
+                            "ssr": false,
+                            "prerender": false,
                             "budgets": [
                                 {
                                     "type": "initial",
@@ -83,6 +85,8 @@
                             "sourceMap": true
                         },
                         "development": {
+                            "ssr": false,
+                            "prerender": false,
                             "optimization": false,
                             "extractLicenses": false,
                             "sourceMap": true


### PR DESCRIPTION
This allows our project to be deployable using the RSL deployment module. It disables SSR/SSG for the frontend (since it adds needless complexity and puts build files in a different file structure). The current settings are taken from [this iAnalyzer commit](https://github.com/CentreForDigitalHumanities/I-analyzer/commit/9f3e948e6922b425ae42f3ecba14bbc6ed92bde4), where Angular is instructed to put the client HTML/JS files straight in the dist folder.

Don't mind the individual commits; I suggest we squash merge all of these 😅 