### PR TITLE
Clear form upon navigating to start

### DIFF
--- a/frontend/src/app/nav-buttons/nav-buttons.component.html
+++ b/frontend/src/app/nav-buttons/nav-buttons.component.html
@@ -15,6 +15,7 @@
                 : 'btn-arrow-left'
         "
         [routerLink]="navButton.link"
+        (click)="navButton.action?.()"
     >
         {{ navButton.label }}
     </a>

--- a/frontend/src/app/nav-buttons/nav-buttons.component.ts
+++ b/frontend/src/app/nav-buttons/nav-buttons.component.ts
@@ -5,6 +5,7 @@ export interface NavButton {
     label: string;
     direction: "next" | "back";
     link: string;
+    action?: () => void;
 }
 
 @Component({
@@ -18,7 +19,7 @@ export class NavButtonsComponent {
 
     // Make sure the buttons are sorted so 'back' comes before 'next'.
     public sorted = computed(() => {
-        const buttons = structuredClone(this.navButtons());
+        const buttons = [...this.navButtons()];
         return buttons.sort((a, b) => {
             if (a.direction === "back" && b.direction === "next") {
                 return -1;

--- a/frontend/src/app/summary/summary.component.ts
+++ b/frontend/src/app/summary/summary.component.ts
@@ -34,6 +34,9 @@ export class SummaryComponent {
             label: $localize`Start over`,
             direction: "next",
             link: "/",
+            action: () => {
+                this.form.reset();
+            }
         },
     ];
     generateReport() {


### PR DESCRIPTION
Close #71.

The navigation buttons component did not support running code upon clicking a button, so I added an `action` property. However, deep clones of functions are not possible, so I had to change the deep clone in the `sorted` computed property to a shallow clone. Since the operation `buttons.sort()` only changes the array but not the objects in itself, I think that this should be safe, but maybe I am overlooking something...!