### PR TITLE
Feature/matomo

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -67,6 +67,12 @@
                     },
                     "configurations": {
                         "production": {
+                            "fileReplacements": [
+                                {
+                                    "replace": "src/environments/environment.ts",
+                                    "with": "src/environments/environment.prod.ts"
+                                }
+                            ],
                             "ssr": false,
                             "prerender": false,
                             "budgets": [

--- a/frontend/locale/messages.nl.xlf
+++ b/frontend/locale/messages.nl.xlf
@@ -369,7 +369,7 @@
       </trans-unit>
       <trans-unit id="8082396782637148201" datatype="html">
         <source> Which ILOs are tested with this assessment? Select one or multiple. </source>
-        <target state="translated"> Welke leerdoelen (ILO's) worden met deze toetsvormen getoetst? Kies er een of meerdere. </target>
+        <target state="translated"> Welke leerdoelen (ILO&apos;s) worden met deze toetsvormen getoetst? Kies er een of meerdere. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/assessments/assessment-subform/assessment-subform.component.html</context>
           <context context-type="linenumber">33</context>
@@ -580,24 +580,24 @@
         </context-group>
       </trans-unit>
       <trans-unit id="5419044235902308391" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> 🌍 Step 1: Learning outcomes analysis <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> clarify and map your course goals. </source>
-        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> 🌍 Stap 1: Leerdoelanalyse <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> zet de doelen van je cursus uiteen. </target>
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> 🌍 Step 1: Learning outcomes analysis <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> clarify and map your course goals. </source>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> 🌍 Stap 1: Leerdoelanalyse <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> zet de doelen van je cursus uiteen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/intro/intro.component.html</context>
           <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5141340214755635116" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> 🚀 Step 2: Assessments <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> assess whether the use of generative AI in assignments negatively impacts the learning outcomes. </source>
-        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> 🚀 Stap 2: Beoordelingen <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> toetst of het gebruik van generatieve AI in opdrachten een negatieve invloed heeft op het behalen van de leerdoelen. </target>
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> 🚀 Step 2: Assessments <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> assess whether the use of generative AI in assignments negatively impacts the learning outcomes. </source>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> 🚀 Stap 2: Beoordelingen <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> toetst of het gebruik van generatieve AI in opdrachten een negatieve invloed heeft op het behalen van de leerdoelen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/intro/intro.component.html</context>
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7046703365220412831" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> 🌙 Step 3: Rethinking courses in times of GenAI <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> explore how generative AI can be used to enhance your course. </source>
-        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> 🌙 Stap 3: Cursussen heroverwegen in tijden van GenAI <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> onderzoekt hoe generatieve AI eventueel gebruikt zou kunnen worden om je cursus te verbeteren. </target>
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> 🌙 Step 3: Rethinking courses in times of GenAI <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> explore how generative AI can be used to enhance your course. </source>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> 🌙 Stap 3: Cursussen heroverwegen in tijden van GenAI <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> onderzoekt hoe generatieve AI eventueel gebruikt zou kunnen worden om je cursus te verbeteren. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/intro/intro.component.html</context>
           <context context-type="linenumber">38</context>
@@ -637,7 +637,7 @@
       </trans-unit>
       <trans-unit id="3355125060616451212" datatype="html">
         <source> In this step, you will map the Intended Learning Outcomes (ILOs) for your course and link each one to the most relevant Dublin Descriptor. </source>
-        <target state="translated"> In deze stap koppel je de beoogde leerdoelen ('Intended Learning Outcomes', ofwel ILO's) voor je cursus aan de meest relevante Dublin-descriptor. </target>
+        <target state="translated"> In deze stap koppel je de beoogde leerdoelen (&apos;Intended Learning Outcomes&apos;, ofwel ILO&apos;s) voor je cursus aan de meest relevante Dublin-descriptor. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/learning-outcomes/learning-outcomes.component.html</context>
           <context context-type="linenumber">6</context>
@@ -825,7 +825,7 @@
       </trans-unit>
       <trans-unit id="5890787992189125196" datatype="html">
         <source> In other words, evaluate whether you think <x id="ICU" equiv-text="{form.controls.iloIds.value.length, plural, =1 {the ILO} other {the ILOs}}" xid="2957047433752626179"/> can still be tested with the chosen type of assignment, assuming that students will use GenAI in the ways listed above and, potentially, more. If you select ‘No’, your assessment is GenAI resilient. Congratulations! If you select ‘Yes’, you will be presented some suggestions to make your assessment more resilient. </source>
-        <target state="translated"> In andere woorden: denk na over de vraag of <x id="ICU" equiv-text="{form.controls.iloIds.value.length, plural, =1 {het leerdoel} other {de leerdoelen}}" xid="2957047433752626179"/> nog steeds behaald kunnen worden met deze beoordeling, in de vooronderstelling dat studenten GenAI op de hierboven beschreven (en wellicht nog andere) manieren zullen gebruiken. Als je 'Nee' antwoordt, dan is je beoordeling AI-bestendig. Gefeliciteerd! Als je 'Ja' kiest, toont deze tool suggesties om je beoordeling bestendiger te maken. </target>
+        <target state="translated"> In andere woorden: denk na over de vraag of <x id="ICU" equiv-text="{form.controls.iloIds.value.length, plural, =1 {het leerdoel} other {de leerdoelen}}" xid="2957047433752626179"/> nog steeds behaald kunnen worden met deze beoordeling, in de vooronderstelling dat studenten GenAI op de hierboven beschreven (en wellicht nog andere) manieren zullen gebruiken. Als je &apos;Nee&apos; antwoordt, dan is je beoordeling AI-bestendig. Gefeliciteerd! Als je &apos;Ja&apos; kiest, toont deze tool suggesties om je beoordeling bestendiger te maken. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/assessments/assessment-subform/assessment-subform.component.html</context>
           <context context-type="linenumber">58</context>
@@ -892,8 +892,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="2568652124050898655" datatype="html">
-        <source> Welcome to the <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>GenAI reflection tool<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>. This tool is designed to reflect on the impact of GenAI on the learning goals of individual courses. It works best if you run this tool with a particular course in mind (and to have the course manual ready). The tool will guide you through some steps (see below) that challenge you to reflect on the validity of the intended learning outcomes of the course and the effectiveness of the assignments to test these. Once finished, you will be offered a report with an overview of the outcomes. </source>
-        <target state="translated"> Welkom in deze <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/> GenAI-reflectietool<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> . Deze tool is ontworpen om je te laten reflecteren op de impact van GenAI op de leerdoelen van individuele cursussen. Het is het beste als je deze tool met een specifieke cursus in gedachte doorloopt (en de cursushandleiding bij de hand houdt). De tool zal je door een aantal stappen leiden (zie hieronder) die je uitdagen om te reflecteren op de validiteit van de beoogde leerdoelen van de cursus en de effectiviteit van de beoordelingen die gebruikt worden om deze te testen. Na afronding biedt deze tool je een rapport met een overzicht van de bevindingen. </target>
+        <source> Welcome to the <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>GenAI reflection tool<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. This tool is designed to reflect on the impact of GenAI on the learning goals of individual courses. It works best if you run this tool with a particular course in mind (and to have the course manual ready). The tool will guide you through some steps (see below) that challenge you to reflect on the validity of the intended learning outcomes of the course and the effectiveness of the assignments to test these. Once finished, you will be offered a report with an overview of the outcomes. </source>
+        <target state="translated"> Welkom in deze <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/> GenAI-reflectietool<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> . Deze tool is ontworpen om je te laten reflecteren op de impact van GenAI op de leerdoelen van individuele cursussen. Het is het beste als je deze tool met een specifieke cursus in gedachte doorloopt (en de cursushandleiding bij de hand houdt). De tool zal je door een aantal stappen leiden (zie hieronder) die je uitdagen om te reflecteren op de validiteit van de beoogde leerdoelen van de cursus en de effectiviteit van de beoordelingen die gebruikt worden om deze te testen. Na afronding biedt deze tool je een rapport met een overzicht van de bevindingen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/intro/intro.component.html</context>
           <context context-type="linenumber">5</context>
@@ -916,8 +916,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="2504644822642478505" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> ✨ Step 4: Report <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> after finishing the tool you can download a report with the most important outcomes. </source>
-        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;>"/> ✨ Stap 4: Rapportage <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> na het doorlopen van de tool kun je een gepersonaliseerd rapport downloaden met de belangrijkste bevindingen. </target>
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> ✨ Step 4: Report <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> after finishing the tool you can download a report with the most important outcomes. </source>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong class=&quot;step-title&quot;&gt;"/> ✨ Stap 4: Rapportage <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> na het doorlopen van de tool kun je een gepersonaliseerd rapport downloaden met de belangrijkste bevindingen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/intro/intro.component.html</context>
           <context context-type="linenumber">44</context>
@@ -925,7 +925,7 @@
       </trans-unit>
       <trans-unit id="6747957211917839470" datatype="html">
         <source> Enter the intended learning outcomes of your course here (one per field). You can do this in your own words. For each ILO you enter, please select the Dublin Descriptor that best aligns. </source>
-        <target state="translated"> Voer hier de beoogde leerdoelen (ILO's) van je cursus in (één per veld). Je kunt dit in je eigen woorden doen. Kies voor iedere ingevoerde ILO de Dublin-descriptor die er het beste bijpast. </target>
+        <target state="translated"> Voer hier de beoogde leerdoelen (ILO&apos;s) van je cursus in (één per veld). Je kunt dit in je eigen woorden doen. Kies voor iedere ingevoerde ILO de Dublin-descriptor die er het beste bijpast. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/learning-outcomes/learning-outcomes.component.html</context>
           <context context-type="linenumber">24</context>
@@ -980,8 +980,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="1208562831617318136" datatype="html">
-        <source> You have completed the <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>GenAI reflection tool<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>! To generate the report, please enter your name and click the button below. </source>
-        <target state="translated"> Dit is het einde van de <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>Reflectietool GenAI<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>! Vul je naam in en klik op de knop hieronder om het rapport aan te maken. </target>
+        <source> You have completed the <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>GenAI reflection tool<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>! To generate the report, please enter your name and click the button below. </source>
+        <target state="translated"> Dit is het einde van de <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Reflectietool GenAI<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>! Vul je naam in en klik op de knop hieronder om het rapport aan te maken. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/summary/summary.component.html</context>
           <context context-type="linenumber">5</context>
@@ -1004,16 +1004,21 @@
         </context-group>
       </trans-unit>
       <trans-unit id="6903182743476576254" datatype="html">
-        <source> This application has been developed by <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:p.huijnen@uu.nl&quot;>"/>Pim Huijnen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> and <x id="START_LINK_1" equiv-text="&lt;a href=&quot;mailto:s.falcke@uu.nl&quot;>"/>Swantje Falcke<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> in collaboration with the <x id="START_LINK_2" equiv-text="&lt;a href=&quot;https://cdh.uu.nl/&quot;>"/>Centre for Digital Humanities<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> within the context of the USO project <x id="START_LINK_3" equiv-text="&lt;a href=&quot;https://teaching-and-learning-collection.sites.uu.nl/project/ai-in-higher-education/&quot; >"/>"AI in Higher Education: Building reflective awareness through educational interventions"<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/>. </source>
-        <target state="translated"> Deze applicatie is ontwikkeld door <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:p.huijnen@uu.nl&quot;>"/>Pim Huijnen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> en <x id="START_LINK_1" equiv-text="&lt;a href=&quot;mailto:s.falcke@uu.nl&quot;>"/>Swantje Falcke<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> in samenwerking met het <x id="START_LINK_2" equiv-text="&lt;a href=&quot;https://cdh.uu.nl/&quot;>"/>Centre for Digital Humanities<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> in het kader van het USO-project <x id="START_LINK_3" equiv-text="&lt;a href=&quot;https://teaching-and-learning-collection.sites.uu.nl/project/ai-in-higher-education/&quot; >"/>"AI in Higher Education: Building reflective awareness through educational interventions"<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/>. </target>
+        <source> This application has been developed by <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:p.huijnen@uu.nl&quot;&gt;"/>Pim Huijnen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> and <x id="START_LINK_1" equiv-text="&lt;a href=&quot;mailto:s.falcke@uu.nl&quot;&gt;"/>Swantje Falcke<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> in collaboration with the <x id="START_LINK_2" equiv-text="&lt;a href=&quot;https://cdh.uu.nl/&quot;&gt;"/>Centre for Digital Humanities<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> within the context of the USO project <x id="START_LINK_3" equiv-text="&lt;a href=&quot;https://teaching-and-learning-collection.sites.uu.nl/project/ai-in-higher-education/&quot; &gt;"/>&quot;AI in Higher Education: Building reflective awareness through educational interventions&quot;<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>. </source>
+        <target state="translated"> Deze applicatie is ontwikkeld door <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:p.huijnen@uu.nl&quot;&gt;"/>Pim Huijnen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> en <x id="START_LINK_1" equiv-text="&lt;a href=&quot;mailto:s.falcke@uu.nl&quot;&gt;"/>Swantje Falcke<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> in samenwerking met het <x id="START_LINK_2" equiv-text="&lt;a href=&quot;https://cdh.uu.nl/&quot;&gt;"/>Centre for Digital Humanities<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> in het kader van het USO-project <x id="START_LINK_3" equiv-text="&lt;a href=&quot;https://teaching-and-learning-collection.sites.uu.nl/project/ai-in-higher-education/&quot; &gt;"/>&quot;AI in Higher Education: Building reflective awareness through educational interventions&quot;<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.html</context>
           <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3477178736438431184" datatype="html">
+<<<<<<< Updated upstream
         <source>You are free to share and adapt the contents of this site, if you give appropriate credit and use it non-commercially. More on <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;>"/>Creative Commons<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>.</source>
         <target state="translated">Je kunt de inhoud van deze website vrij hergebruiken, mits je bronvermelding geeft en het gaat om niet-commercieel gebruik. Meer informatie op <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;>"/>Creative Commons<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>.</target>
+=======
+        <source>You are free to share and adapt the contents of this site, if you give appropriate credit and use it non-commercially. More on <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot; &gt;"/>Creative Commons<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>.</source>
+        <target state="translated">Je kunt de inhoud van deze website vrij hergebruiken, mits je bronvermelding geeft en het gaat om niet-commercieel gebruik. Meer informatie op <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;"/>Creative Commons<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+>>>>>>> Stashed changes
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.html</context>
           <context context-type="linenumber">67</context>
@@ -1044,8 +1049,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="3404771349533216677" datatype="html">
-        <source> Below you will find a scale with five levels of AI integration in educational assessments, based on the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; target=&quot;_blank&quot; i18n-href=&quot;url&quot; >"/>AI Index<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> for teachers, as adopted by Utrecht University. Additional information regarding the university policy on generative AI can be found <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; >"/>here<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/>. (Both links will open in a new tab). </source>
-        <target state="translated"> Hieronder vind je een schaal met vijf niveaus waarin generatieve AI in educatieve opdrachten geïntegreerd kan worden, gebaseerd op de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; target=&quot;_blank&quot; i18n-href=&quot;url&quot; >"/>AI-index<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/> voor docenten, zoals aangenomen door de Universiteit Utrecht. Meer informatie over het universiteitsbeleid ten opzichte van generatieve AI vind je <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; >"/>hier<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a >"/>. (Beide links openen in een nieuw tabblad). </target>
+        <source> Below you will find a scale with five levels of AI integration in educational assessments, based on the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; target=&quot;_blank&quot; i18n-href=&quot;url&quot; &gt;"/>AI Index<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> for teachers, as adopted by Utrecht University. Additional information regarding the university policy on generative AI can be found <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; &gt;"/>here<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>. (Both links will open in a new tab). </source>
+        <target state="translated"> Hieronder vind je een schaal met vijf niveaus waarin generatieve AI in educatieve opdrachten geïntegreerd kan worden, gebaseerd op de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; target=&quot;_blank&quot; i18n-href=&quot;url&quot; &gt;"/>AI-index<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/> voor docenten, zoals aangenomen door de Universiteit Utrecht. Meer informatie over het universiteitsbeleid ten opzichte van generatieve AI vind je <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; &gt;"/>hier<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>. (Beide links openen in een nieuw tabblad). </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/course-integration/course-integration.component.html</context>
           <context context-type="linenumber">17</context>
@@ -1060,8 +1065,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="8702591476857460684" datatype="html">
-        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; >"/> AI Index <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;ms-2 fst-italic&quot; >"/>(Link will open in a new tab.)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span >"/></source>
-        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; >"/> AI-index <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;ms-2 fst-italic&quot; >"/>(Link opent in een nieuw tabblad.)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span >"/></target>
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; &gt;"/> AI Index <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;ms-2 fst-italic&quot; &gt;"/>(Link will open in a new tab.)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span &gt;"/></source>
+        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://www.uu.nl/en/organisation/ai-policy/teachers/for-teachers/ai-index&quot; i18n-href=&quot;url&quot; target=&quot;_blank&quot; &gt;"/> AI-index <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;ms-2 fst-italic&quot; &gt;"/>(Link opent in een nieuw tabblad.)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span &gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/course-integration/course-integration.component.html</context>
           <context context-type="linenumber">140</context>
@@ -1106,8 +1111,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="7004509894453603914" datatype="html">
-        <source> You are welcome to send your own suggestions for adjustments to <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;>"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </source>
-        <target state="translated"> Je kunt eigen suggesties voor aanpassingen opsturen naar <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;>"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </target>
+        <source> You are welcome to send your own suggestions for adjustments to <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;&gt;"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
+        <target state="translated"> Je kunt eigen suggesties voor aanpassingen opsturen naar <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;&gt;"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/assessments/assessment-subform/assessment-subform.component.html</context>
           <context context-type="linenumber">54</context>
@@ -1122,8 +1127,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="2834029339840963501" datatype="html">
-        <source> You are welcome to send your own examples of students' GenAI usages to <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;>"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </source>
-        <target state="translated"> Je kunt eigen voorbeelden van GenAI-gebruik door studenten opsturen naar <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;>"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </target>
+        <source> You are welcome to send your own examples of students&apos; GenAI usages to <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;&gt;"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
+        <target state="translated"> Je kunt eigen voorbeelden van GenAI-gebruik door studenten opsturen naar <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;&gt;"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/assessments/assessment-subform/known-uses-examples/known-uses-examples.component.html</context>
           <context context-type="linenumber">16</context>
@@ -1142,8 +1147,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="9059562274664569381" datatype="html">
-        <source> You are welcome to send your own examples for AI usages to <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;>"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </source>
-        <target state="translated"> Je kunt eigen voorbeelden van AI-gebruik opsturen naar <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;>"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </target>
+        <source> You are welcome to send your own examples for AI usages to <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;&gt;"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
+        <target state="translated"> Je kunt eigen voorbeelden van AI-gebruik opsturen naar <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:genaitool@uu.nl&quot;&gt;"/>genaitool@uu.nl<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/course-integration/course-integration.component.html</context>
           <context context-type="linenumber">73</context>
@@ -1158,8 +1163,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="1487060317235678044" datatype="html">
-        <source> Please enter a course name (on the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;['/', 'intro']&quot;>"/>introduction page<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>). </source>
-        <target state="translated"> Vul de naam van je cursus in (op de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;['/', 'intro']&quot;>"/>introductiepagina<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>). </target>
+        <source> Please enter a course name (on the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;[&apos;/&apos;, &apos;intro&apos;]&quot;&gt;"/>introduction page<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>). </source>
+        <target state="translated"> Vul de naam van je cursus in (op de <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;[&apos;/&apos;, &apos;intro&apos;]&quot;&gt;"/>introductiepagina<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>). </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/summary/summary.component.html</context>
           <context context-type="linenumber">30</context>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
         "bootstrap": "^5.3.3",
         "colors": "^1.4.0",
         "express": "^4.18.2",
+        "ngx-matomo-client": "8.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "uu-bootstrap": "git+https://github.com/UtrechtUniversity/UU-Bootstrap.git#1.4.0",

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -29,13 +29,13 @@ export const appConfig: ApplicationConfig = {
                 headerName: "X-CSRFToken",
             }),
         ),
-        provideMatomo({
-            trackerUrl: environment.matomo.url,
-            siteId: environment.matomo.siteId,
-            acceptDoNotTrack: false,
-        },
-            withRouter()
-        ),
+        ...('matomo' in environment ? [
+            provideMatomo({
+                siteId: environment.matomo.siteId,
+                trackerUrl: environment.matomo.url,
+                acceptDoNotTrack: false,
+            }, withRouter()),
+        ] : []),
         // The language is used as the base_path for finding the right
         // static-files. For example /nl/static/main.js
         // However the routing is done from a base path starting from

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -6,8 +6,6 @@ import {
     withInterceptors,
     withXsrfConfiguration,
 } from "@angular/common/http";
-import { provideClientHydration } from "@angular/platform-browser";
-import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
 
 import { routes } from "./app.routes";
@@ -15,33 +13,35 @@ import { platformInterceptor } from "./interceptors/platformInterceptor";
 import { provideMatomo, withRouter } from 'ngx-matomo-client';
 import { environment } from "../environments/environment";
 
-export const appConfig: ApplicationConfig = {
-    providers: [
-        provideAnimations(),
-        provideZoneChangeDetection({ eventCoalescing: true }),
-        provideRouter(routes),
-        // provideClientHydration(),
-        provideHttpClient(
-            withFetch(),
-            withInterceptors([platformInterceptor]),
-            withXsrfConfiguration({
-                cookieName: "csrftoken",
-                headerName: "X-CSRFToken",
-            }),
+const providers = [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient(
+        withFetch(),
+        withInterceptors([platformInterceptor]),
+        withXsrfConfiguration({
+            cookieName: "csrftoken",
+            headerName: "X-CSRFToken",
+        }),
+    ),
+    // The language is used as the base_path for finding the right
+    // static-files. For example /nl/static/main.js
+    // However the routing is done from a base path starting from
+    // the root e.g. /home
+    // The server should then switch index.html based on a language
+    // cookie with a fallback to Dutch e.g. /nl/static/index.html
+    { provide: APP_BASE_HREF, useValue: "/" },
+];
+
+if (environment.matomo) {
+    providers.push(
+        provideMatomo(
+            environment.matomo,
+            withRouter()
         ),
-        ...('matomo' in environment ? [
-            provideMatomo({
-                siteId: environment.matomo.siteId,
-                trackerUrl: environment.matomo.url,
-                acceptDoNotTrack: false,
-            }, withRouter()),
-        ] : []),
-        // The language is used as the base_path for finding the right
-        // static-files. For example /nl/static/main.js
-        // However the routing is done from a base path starting from
-        // the root e.g. /home
-        // The server should then switch index.html based on a language
-        // cookie with a fallback to Dutch e.g. /nl/static/index.html
-        { provide: APP_BASE_HREF, useValue: "/" },
-    ],
+    );
+}
+
+export const appConfig: ApplicationConfig = {
+    providers
 };

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -12,13 +12,15 @@ import { provideRouter } from "@angular/router";
 
 import { routes } from "./app.routes";
 import { platformInterceptor } from "./interceptors/platformInterceptor";
+import { provideMatomo, withRouter } from 'ngx-matomo-client';
+import { environment } from "../environments/environment";
 
 export const appConfig: ApplicationConfig = {
     providers: [
         provideAnimations(),
         provideZoneChangeDetection({ eventCoalescing: true }),
         provideRouter(routes),
-        provideClientHydration(),
+        // provideClientHydration(),
         provideHttpClient(
             withFetch(),
             withInterceptors([platformInterceptor]),
@@ -26,6 +28,13 @@ export const appConfig: ApplicationConfig = {
                 cookieName: "csrftoken",
                 headerName: "X-CSRFToken",
             }),
+        ),
+        provideMatomo({
+            trackerUrl: environment.matomo.url,
+            siteId: environment.matomo.siteId,
+            acceptDoNotTrack: false,
+        },
+            withRouter()
         ),
         // The language is used as the base_path for finding the right
         // static-files. For example /nl/static/main.js

--- a/frontend/src/environments/environment.interface.ts
+++ b/frontend/src/environments/environment.interface.ts
@@ -1,0 +1,12 @@
+import { MatomoConfiguration } from "ngx-matomo-client";
+
+
+export interface Environment {
+    production: boolean;
+    assets: string;
+    baseUrl: string;
+    buildTime: string;
+    version: string;
+    sourceUrl: string;
+    matomo?: MatomoConfiguration;
+}

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -8,4 +8,8 @@ export const environment = {
     buildTime,
     version,
     sourceUrl,
+    matomo: {
+        siteId: "2",
+        url: "http://127.0.0.1:8080/"
+    }
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 import { buildTime, version, sourceUrl } from "./version";
+import { Environment } from "./environment.interface";
 
 export const environment = {
     production: true,
@@ -10,6 +11,7 @@ export const environment = {
     sourceUrl,
     matomo: {
         siteId: "2",
-        url: "http://127.0.0.1:8080/"
+        trackerUrl: "http://127.0.0.1:8080/",
+        acceptDoNotTrack: true,
     }
-};
+} satisfies Environment;

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -10,10 +10,11 @@ export const environment = {
     buildTime,
     version,
     sourceUrl,
-    matomo: {
-        siteId: "2",
-        url: "http://127.0.0.1:8080/"
-    }
+    // Uncomment if using a local Matomo instance for development.
+    // matomo: {
+    //     siteId: "2",
+    //     url: "http://localhost:8080/"
+    // }
 };
 
 /*

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -2,8 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 import { buildTime, version, sourceUrl } from "./version";
+import { Environment } from "./environment.interface";
 
-export const environment = {
+export const environment: Environment = {
     production: false,
     assets: "assets",
     baseUrl: "http://127.0.0.1:8000",
@@ -13,7 +14,7 @@ export const environment = {
     // Uncomment if using a local Matomo instance for development.
     // matomo: {
     //     siteId: "2",
-    //     url: "http://localhost:8080/"
+    //     trackerUrl: "http://localhost:8080/"
     // }
 };
 

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -10,6 +10,10 @@ export const environment = {
     buildTime,
     version,
     sourceUrl,
+    matomo: {
+        siteId: "2",
+        url: "http://127.0.0.1:8080/"
+    }
 };
 
 /*

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3804,6 +3804,13 @@ ng-extract-i18n-merge@^3.1.0:
     "@schematics/angular" "^20.0.0"
     xmldoc "^1.1.3"
 
+ngx-matomo-client@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ngx-matomo-client/-/ngx-matomo-client-8.0.0.tgz#1f2aac28e9e0da9b42d313c29919b04b45a1aaec"
+  integrity sha512-ztZankR5dfSjMYBn4n19w5yNJUZvpvTKZot+nvzxMO+0FUHbZz97rsJVBwA2Hg2wv6YvqU2GZ6KSMS4Fz0XoVg==
+  dependencies:
+    tslib "^2.3.0"
+
 node-addon-api@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"


### PR DESCRIPTION
Closes #10 

This PR adds Matomo to the application to track page visits. The application has been deployed to the [ACC server](https://acc.gen-ai-reflection.hum.uu.nl) but I'm not sure it's working correctly. I can see Matomo requests going out (the `204 - No Content` status code is expected) but I see no traffic in the dashboard. Maybe this is because `acceptDoNotTrack` is set to `true` and every browser I have requests DNT?

(FireFox always sends `DNT: 1` as a Request Header, and you cannot turn it off anymore, cf. [this article](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature?as=u&utm_source=inproduct).

Would you be able to test this?

Good to know: for local testing of this and other applications, I have created [this repo](https://github.com/CentreForDigitalHumanities/matomo-dev) that lets you build a local Matomo instance (in Docker). I did manage to see stats in my local Matomo instance, but I had `acceptDoNotTrack` set to false there.

I am also updating the [RSL-Info docs](https://github.com/CentreForDigitalHumanities/rsl-info/pull/99) on Matomo with lessons learned in this PR.